### PR TITLE
feat: configure per-page meta tags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from '@/components/ui/sonner';
 import CountryRedirect from '@/components/CountryRedirect';
+import Meta from '@/components/Meta';
 
 // Page imports
 import Index from '@/pages/Index';
@@ -102,6 +103,7 @@ const App: React.FC = () => {
       <Router>
         <AuthProvider>
           <CountryRedirect />
+          <Meta />
           <div className="App">
             <Routes>
               {/* Home routes */}

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import meta from '@/data/meta';
+
+const countries = ['singapore', 'sri-lanka', 'myanmar', 'bangladesh', 'pakistan', 'home'];
+
+const Meta = () => {
+  const { pathname } = useLocation();
+  const parts = pathname.split('/').filter(Boolean);
+  let pathKey = '/' + parts.join('/');
+
+  if (parts.length > 0 && countries.includes(parts[0])) {
+    pathKey = '/' + parts.slice(1).join('/');
+  }
+
+  if (pathKey === '/' || pathKey === '') {
+    pathKey = '/';
+  }
+
+  if (pathKey === '/home') {
+    pathKey = '/';
+  }
+
+  const metaData = meta[pathKey] || meta['/'];
+
+  useEffect(() => {
+    document.title = metaData.title;
+
+    const setMeta = (name: string, content: string) => {
+      let element = document.querySelector(`meta[name="${name}"]`) as HTMLMetaElement | null;
+      if (!element) {
+        element = document.createElement('meta');
+        element.setAttribute('name', name);
+        document.head.appendChild(element);
+      }
+      element.setAttribute('content', content);
+    };
+
+    setMeta('description', metaData.description);
+    setMeta('keywords', metaData.keywords);
+  }, [metaData]);
+
+  return null;
+};
+
+export default Meta;

--- a/src/data/meta.ts
+++ b/src/data/meta.ts
@@ -1,0 +1,165 @@
+interface MetaInfo {
+  title: string;
+  description: string;
+  keywords: string;
+}
+
+const meta: Record<string, MetaInfo> = {
+  '/': {
+    title: 'OECL - Logistics & Transportation',
+    description: 'Reliable and efficient logistics solutions tailored to your business needs.',
+    keywords: 'logistics, shipping, OECL, transportation, global consolidators',
+  },
+  '/contact': {
+    title: 'Contact OECL',
+    description: 'Get in touch with OECL for inquiries about our logistics services.',
+    keywords: 'contact, OECL, logistics, support',
+  },
+  '/services': {
+    title: 'OECL Services',
+    description: 'Explore OECL’s comprehensive range of logistics and transportation services.',
+    keywords: 'services, logistics, transportation, OECL',
+  },
+  '/services/sea-freight': {
+    title: 'Sea Freight Services - OECL',
+    description: 'Cost-effective sea freight solutions for global cargo movement.',
+    keywords: 'sea freight, ocean shipping, logistics',
+  },
+  '/services/air-freight': {
+    title: 'Air Freight Services - OECL',
+    description: 'Fast and reliable air freight services to meet urgent shipping needs.',
+    keywords: 'air freight, air cargo, logistics',
+  },
+  '/services/customs-clearance': {
+    title: 'Customs Clearance - OECL',
+    description: 'Efficient customs clearance services ensuring smooth cargo handling.',
+    keywords: 'customs clearance, import export, logistics',
+  },
+  '/services/warehousing': {
+    title: 'Warehousing Solutions - OECL',
+    description: 'Secure and scalable warehousing solutions for your supply chain.',
+    keywords: 'warehousing, storage, logistics',
+  },
+  '/services/consolidation': {
+    title: 'Cargo Consolidation - OECL',
+    description: 'Optimize shipments with OECL’s cargo consolidation services.',
+    keywords: 'cargo consolidation, logistics, shipping',
+  },
+  '/services/project-cargo': {
+    title: 'Project Cargo Handling - OECL',
+    description: 'Specialized project cargo services for oversized and heavy shipments.',
+    keywords: 'project cargo, heavy lift, logistics',
+  },
+  '/services/liquid-cargo': {
+    title: 'Liquid Cargo Transport - OECL',
+    description: 'Safe and efficient transportation solutions for liquid cargo.',
+    keywords: 'liquid cargo, bulk liquids, logistics',
+  },
+  '/services/third-party-logistics': {
+    title: 'Third Party Logistics - OECL',
+    description: 'Comprehensive 3PL services tailored to your business.',
+    keywords: '3PL, third-party logistics, supply chain',
+  },
+  '/services/liner-agency': {
+    title: 'Liner Agency Services - OECL',
+    description: 'Professional liner agency services supporting global shipping lines.',
+    keywords: 'liner agency, shipping lines, logistics',
+  },
+  '/global-presence': {
+    title: 'OECL Global Presence',
+    description: 'Discover OECL’s growing global footprint and regional offices.',
+    keywords: 'global presence, offices, logistics network',
+  },
+  '/about-us': {
+    title: 'About OECL',
+    description: 'Learn more about OECL’s mission, vision, and experienced team.',
+    keywords: 'about OECL, company info, logistics',
+  },
+  '/gallery': {
+    title: 'OECL Gallery',
+    description: 'Browse images showcasing OECL’s operations and services.',
+    keywords: 'gallery, images, OECL',
+  },
+  '/career': {
+    title: 'Careers at OECL',
+    description: 'Join OECL’s team and advance your career in logistics.',
+    keywords: 'careers, jobs, OECL',
+  },
+  '/blog': {
+    title: 'OECL Blog',
+    description: 'Latest insights and updates from OECL’s logistics experts.',
+    keywords: 'blog, logistics news, OECL',
+  },
+  '/news': {
+    title: 'OECL News',
+    description: 'Company news and industry updates from OECL.',
+    keywords: 'news, updates, OECL',
+  },
+  '/projects': {
+    title: 'OECL Projects',
+    description: 'Explore notable logistics projects handled by OECL.',
+    keywords: 'projects, case studies, logistics',
+  },
+  '/privacy-policy': {
+    title: 'Privacy Policy - OECL',
+    description: 'Read OECL’s commitment to protecting your privacy.',
+    keywords: 'privacy policy, data protection, OECL',
+  },
+  '/terms-and-conditions': {
+    title: 'Terms & Conditions - OECL',
+    description: 'Review the terms and conditions for using OECL services.',
+    keywords: 'terms and conditions, policies, OECL',
+  },
+  '/login': {
+    title: 'OECL Login',
+    description: 'Access your OECL account.',
+    keywords: 'login, account, OECL',
+  },
+  '/signup': {
+    title: 'OECL Signup',
+    description: 'Create an account with OECL to manage your shipments.',
+    keywords: 'signup, register, OECL',
+  },
+  '/forgot-password': {
+    title: 'Forgot Password - OECL',
+    description: 'Reset your OECL account password.',
+    keywords: 'password reset, account recovery, OECL',
+  },
+  '/dashboard': {
+    title: 'OECL Dashboard',
+    description: 'Manage your shipments, documents, and payments in the OECL dashboard.',
+    keywords: 'dashboard, shipments, OECL',
+  },
+  '/admin-login': {
+    title: 'Admin Login - OECL',
+    description: 'Administrative access to OECL’s management tools.',
+    keywords: 'admin login, OECL',
+  },
+  '/admin-dashboard': {
+    title: 'OECL Admin Dashboard',
+    description: 'Administration panel for managing OECL operations.',
+    keywords: 'admin dashboard, management, OECL',
+  },
+  '/admin': {
+    title: 'OECL Admin Dashboard',
+    description: 'Administration panel for managing OECL operations.',
+    keywords: 'admin dashboard, management, OECL',
+  },
+  '/blog-editor': {
+    title: 'OECL Blog Editor',
+    description: 'Create and edit blog posts for OECL.',
+    keywords: 'blog editor, content management, OECL',
+  },
+  '/blog-admin': {
+    title: 'OECL Blog Admin',
+    description: 'Administer blog content at OECL.',
+    keywords: 'blog admin, content, OECL',
+  },
+  '/not-found': {
+    title: 'Page Not Found - OECL',
+    description: 'The page you are looking for could not be found.',
+    keywords: '404, not found, OECL',
+  },
+};
+
+export default meta;


### PR DESCRIPTION
## Summary
- add Meta component that updates title, description and keywords based on current route
- map routes to meta details so each page has unique SEO tags
- hook Meta into main App to run on navigation

## Testing
- `npm run lint` *(fails: Unexpected any and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c3c3be37083309dbefd032239c3eb