### PR TITLE
Center service category images

### DIFF
--- a/src/pages/services/IndiaServices.tsx
+++ b/src/pages/services/IndiaServices.tsx
@@ -25,11 +25,11 @@ const ServiceCard = ({ title, description, icon: Icon, image, link }) => {
       viewport={{ once: true }}
       className="bg-white rounded-xl overflow-hidden shadow-md hover:shadow-xl transition-all duration-300 group grid grid-cols-1 md:grid-cols-2"
     >
-      <div className="w-full h-48 md:h-64">
+      <div className="w-full h-48 md:h-64 flex items-center justify-center">
         <img
           src={image}
           alt={title}
-          className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          className="h-full w-auto object-contain transition-transform duration-500 group-hover:scale-105"
         />
       </div>
       <div className="p-6 flex flex-col justify-center bg-gray-200">

--- a/src/pages/services/IndonesiaServices.tsx
+++ b/src/pages/services/IndonesiaServices.tsx
@@ -25,11 +25,11 @@ const ServiceCard = ({ title, description, icon: Icon, image, link }) => {
       viewport={{ once: true }}
       className="bg-white rounded-xl overflow-hidden shadow-md hover:shadow-xl transition-all duration-300 group grid grid-cols-1 md:grid-cols-2"
     >
-      <div className="w-full h-48 md:h-64">
+      <div className="w-full h-48 md:h-64 flex items-center justify-center">
         <img
           src={image}
           alt={title}
-          className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          className="h-full w-auto object-contain transition-transform duration-500 group-hover:scale-105"
         />
       </div>
       <div className="p-6 flex flex-col justify-center bg-gray-200">

--- a/src/pages/services/MalaysiaServices.tsx
+++ b/src/pages/services/MalaysiaServices.tsx
@@ -25,11 +25,11 @@ const ServiceCard = ({ title, description, icon: Icon, image, link }) => {
       viewport={{ once: true }}
       className="bg-white rounded-xl overflow-hidden shadow-md hover:shadow-xl transition-all duration-300 group grid grid-cols-1 md:grid-cols-2"
     >
-      <div className="w-full h-48 md:h-64">
+      <div className="w-full h-48 md:h-64 flex items-center justify-center">
         <img
           src={image}
           alt={title}
-          className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          className="h-full w-auto object-contain transition-transform duration-500 group-hover:scale-105"
         />
       </div>
       <div className="p-6 flex flex-col justify-center bg-gray-200">

--- a/src/pages/services/ThailandServices.tsx
+++ b/src/pages/services/ThailandServices.tsx
@@ -25,11 +25,11 @@ const ServiceCard = ({ title, description, icon: Icon, image, link }) => {
       viewport={{ once: true }}
       className="bg-white rounded-xl overflow-hidden shadow-md hover:shadow-xl transition-all duration-300 group grid grid-cols-1 md:grid-cols-2"
     >
-      <div className="w-full h-48 md:h-64">
+      <div className="w-full h-48 md:h-64 flex items-center justify-center">
         <img
           src={image}
           alt={title}
-          className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          className="h-full w-auto object-contain transition-transform duration-500 group-hover:scale-105"
         />
       </div>
       <div className="p-6 flex flex-col justify-center bg-gray-200">


### PR DESCRIPTION
## Summary
- Center images in regional service category cards
- Ensure service card images use `object-contain` for consistent display

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0708039d88330a90d3e195ab12297