### PR TITLE
Center images on service category pages

### DIFF
--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -51,7 +51,7 @@ const ServiceCard: React.FC<ServiceCardProps> = ({
     once: true
   }} className="bg-white rounded-xl overflow-hidden shadow-md hover:shadow-xl transition-all duration-300 group grid grid-cols-1 md:grid-cols-2">
       <div className="w-full h-48 md:h-64">
-        <img src={image} alt={title} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" />
+        <img src={image} alt={title} className="w-full h-full object-cover mx-auto transition-transform duration-500 group-hover:scale-105" />
       </div>
       <div className="p-6 flex flex-col justify-center bg-gradient-to-br from-gc-light-gold/10 to-gc-gold/5 bg-stone-200">
         <div className="bg-blue-200 text-gc-dark-blue p-2 rounded-full inline-block mb-2 w-fit">

--- a/src/pages/services/AirFreight.tsx
+++ b/src/pages/services/AirFreight.tsx
@@ -71,7 +71,7 @@ const AirFreight = () => {
             delay: 0.2
           }} className="relative">
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/airfreight.png" alt="Air Freight Services" className="w-full h-96 object-cover" />
+                <img src="/airfreight.png" alt="Air Freight Services" className="w-full h-96 object-cover mx-auto" />
               </div>
             </motion.div>
 

--- a/src/pages/services/Consolidation.tsx
+++ b/src/pages/services/Consolidation.tsx
@@ -42,7 +42,7 @@ const Consolidation = () => {
               className="relative"
             >
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/consolidation.png" alt="Consolidation" className="w-full h-96 object-cover" />
+                <img src="/consolidation.png" alt="Consolidation" className="w-full h-96 object-cover mx-auto" />
               </div>
             </motion.div>
 

--- a/src/pages/services/CustomsClearance.tsx
+++ b/src/pages/services/CustomsClearance.tsx
@@ -47,7 +47,7 @@ const CustomsClearance = () => {
             delay: 0.2
           }} className="relative">
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/customclearance.png" alt="Customs Clearance Services" className="w-full h-96 object-cover" />
+                <img src="/customclearance.png" alt="Customs Clearance Services" className="w-full h-96 object-cover mx-auto" />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"></div>
               </div>
             </motion.div>

--- a/src/pages/services/IndiaServices.tsx
+++ b/src/pages/services/IndiaServices.tsx
@@ -29,7 +29,7 @@ const ServiceCard = ({ title, description, icon: Icon, image, link }) => {
         <img
           src={image}
           alt={title}
-          className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          className="w-full h-full object-cover mx-auto transition-transform duration-500 group-hover:scale-105"
         />
       </div>
       <div className="p-6 flex flex-col justify-center bg-gray-200">

--- a/src/pages/services/IndonesiaServices.tsx
+++ b/src/pages/services/IndonesiaServices.tsx
@@ -29,7 +29,7 @@ const ServiceCard = ({ title, description, icon: Icon, image, link }) => {
         <img
           src={image}
           alt={title}
-          className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          className="w-full h-full object-cover mx-auto transition-transform duration-500 group-hover:scale-105"
         />
       </div>
       <div className="p-6 flex flex-col justify-center bg-gray-200">

--- a/src/pages/services/LinearAgency.tsx
+++ b/src/pages/services/LinearAgency.tsx
@@ -47,7 +47,7 @@ const LinearAgency = () => {
             delay: 0.2
           }} className="relative">
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/linearagency.png" alt="Linear Agency Services" className="w-full h-96 object-cover" />
+                <img src="/linearagency.png" alt="Linear Agency Services" className="w-full h-96 object-cover mx-auto" />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"></div>
               </div>
             </motion.div>

--- a/src/pages/services/LinerAgency.tsx
+++ b/src/pages/services/LinerAgency.tsx
@@ -42,7 +42,7 @@ const LinerAgency = () => {
               className="relative"
             >
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/linearagency.png" alt="Liner Agency" className="w-full h-96 object-cover" />
+                <img src="/linearagency.png" alt="Liner Agency" className="w-full h-96 object-cover mx-auto" />
               </div>
             </motion.div>
 

--- a/src/pages/services/LiquidCargo.tsx
+++ b/src/pages/services/LiquidCargo.tsx
@@ -47,7 +47,7 @@ const LiquidCargo = () => {
             delay: 0.2
           }} className="relative">
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/liquidtransportation.png" alt="Liquid Cargo Transportation" className="w-full h-96 object-cover" />
+                <img src="/liquidtransportation.png" alt="Liquid Cargo Transportation" className="w-full h-96 object-cover mx-auto" />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"></div>
               </div>
             </motion.div>

--- a/src/pages/services/LiquidTransportation.tsx
+++ b/src/pages/services/LiquidTransportation.tsx
@@ -41,7 +41,7 @@ const LiquidTransportation = () => {
               className="relative"
             >
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/liquidtransportation.png" alt="Liquid Transportation" className="w-full h-96 object-cover" />
+                <img src="/liquidtransportation.png" alt="Liquid Transportation" className="w-full h-96 object-cover mx-auto" />
                 <div className="absolute top-4 left-4 bg-red-600 text-white px-3 py-1 rounded-full text-lg font-bold">
                   7584
                 </div>

--- a/src/pages/services/MalaysiaServices.tsx
+++ b/src/pages/services/MalaysiaServices.tsx
@@ -29,7 +29,7 @@ const ServiceCard = ({ title, description, icon: Icon, image, link }) => {
         <img
           src={image}
           alt={title}
-          className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          className="w-full h-full object-cover mx-auto transition-transform duration-500 group-hover:scale-105"
         />
       </div>
       <div className="p-6 flex flex-col justify-center bg-gray-200">

--- a/src/pages/services/OceanFreight.tsx
+++ b/src/pages/services/OceanFreight.tsx
@@ -48,7 +48,7 @@ const OceanFreight = () => {
             delay: 0.2
           }} className="relative">
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/oceanfreight.png" alt="Ocean Freight Services" className="w-full h-96 object-cover" />
+                <img src="/oceanfreight.png" alt="Ocean Freight Services" className="w-full h-96 object-cover mx-auto" />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"></div>
               </div>
             </motion.div>

--- a/src/pages/services/ProjectCargo.tsx
+++ b/src/pages/services/ProjectCargo.tsx
@@ -44,7 +44,7 @@ const ProjectCargo = () => {
             delay: 0.2
           }} className="relative">
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/projectcargo.png" alt="Project Cargo" className="w-full h-96 object-cover" />
+                <img src="/projectcargo.png" alt="Project Cargo" className="w-full h-96 object-cover mx-auto" />
               </div>
             </motion.div>
 

--- a/src/pages/services/SeaFreight.tsx
+++ b/src/pages/services/SeaFreight.tsx
@@ -46,7 +46,7 @@ const SeaFreight = () => {
             delay: 0.2
           }} className="relative">
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/oceanfreight.png" alt="SEA Freight" className="w-full h-96 object-cover" />
+                <img src="/oceanfreight.png" alt="SEA Freight" className="w-full h-96 object-cover mx-auto" />
               </div>
             </motion.div>
 

--- a/src/pages/services/ThailandServices.tsx
+++ b/src/pages/services/ThailandServices.tsx
@@ -29,7 +29,7 @@ const ServiceCard = ({ title, description, icon: Icon, image, link }) => {
         <img
           src={image}
           alt={title}
-          className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          className="w-full h-full object-cover mx-auto transition-transform duration-500 group-hover:scale-105"
         />
       </div>
       <div className="p-6 flex flex-col justify-center bg-gray-200">

--- a/src/pages/services/ThirdPartyLogistics.tsx
+++ b/src/pages/services/ThirdPartyLogistics.tsx
@@ -44,7 +44,7 @@ const ThirdPartyLogistics = () => {
             delay: 0.2
           }} className="relative">
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/3pl.png" alt="3PL" className="w-full h-96 object-cover" />
+                <img src="/3pl.png" alt="3PL" className="w-full h-96 object-cover mx-auto" />
               </div>
             </motion.div>
 

--- a/src/pages/services/Warehousing.tsx
+++ b/src/pages/services/Warehousing.tsx
@@ -44,7 +44,7 @@ const Warehousing = () => {
             delay: 0.2
           }} className="relative">
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img src="/warehousing.png" alt="Warehousing Services" className="w-full h-96 object-cover" />
+                <img src="/warehousing.png" alt="Warehousing Services" className="w-full h-96 object-cover mx-auto" />
               </div>
             </motion.div>
 


### PR DESCRIPTION
## Summary
- Centered service category page images by adding `mx-auto` to image classes across all service components.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 47 problems (33 errors, 14 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c07244f7d88330ad6cf4d35012fc02