### PR TITLE
Add folder-based gallery organization

### DIFF
--- a/src/pages/BlogEditor.tsx
+++ b/src/pages/BlogEditor.tsx
@@ -87,6 +87,7 @@ const BlogEditor = () => {
     description: "",
     country: "singapore",
     label: "",
+    folder: "",
     file: null as File | null,
   });
 
@@ -485,7 +486,9 @@ const BlogEditor = () => {
     try {
       const fileExt = galleryUploadForm.file.name.split('.').pop();
       const fileName = `${Date.now()}.${fileExt}`;
-      const filePath = `${fileName}`;
+      const filePath = galleryUploadForm.folder
+        ? `${galleryUploadForm.folder}/${fileName}`
+        : `${fileName}`;
 
       console.log(`Uploading to gallery-${galleryUploadForm.country} bucket:`, filePath);
 
@@ -525,7 +528,7 @@ const BlogEditor = () => {
         description: "The image has been added to the gallery",
       });
 
-      setGalleryUploadForm({ title: "", description: "", country: "singapore", label: "", file: null });
+      setGalleryUploadForm({ title: "", description: "", country: "singapore", label: "", folder: "", file: null });
       if (galleryUploadForm.country === selectedCountry) {
         fetchGalleryImages();
       }
@@ -1058,7 +1061,16 @@ const BlogEditor = () => {
                 placeholder="e.g., private (to hide from public)"
               />
             </div>
-            
+
+            <div>
+              <Label>Folder (Optional)</Label>
+              <Input
+                value={galleryUploadForm.folder}
+                onChange={(e) => setGalleryUploadForm({ ...galleryUploadForm, folder: e.target.value })}
+                placeholder="Enter folder name"
+              />
+            </div>
+
             <div>
               <Label>Image File *</Label>
               <Input

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -36,12 +36,13 @@ const ForgotPassword = () => {
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
         redirectTo: `${window.location.origin}/reset-password`,
       });
-      
+
       if (error) throw error;
-      
+
       setIsSubmitted(true);
-    } catch (error: any) {
-      setError(error.message);
+    } catch (error: unknown) {
+      const err = error as Error;
+      setError(err.message);
     } finally {
       setIsLoading(false);
     }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -33,8 +33,9 @@ const Login = () => {
     
     try {
       await signIn(email, password);
-    } catch (error: any) {
-      setError(error.message);
+    } catch (error: unknown) {
+      const err = error as Error;
+      setError(err.message);
     } finally {
       setIsLoading(false);
     }

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -41,8 +41,9 @@ const Signup = () => {
     
     try {
       await signUp(email, password, firstName, lastName);
-    } catch (error: any) {
-      setError(error.message);
+    } catch (error: unknown) {
+      const err = error as Error;
+      setError(err.message);
     } finally {
       setIsLoading(false);
     }

--- a/src/pages/admin/Users.tsx
+++ b/src/pages/admin/Users.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -38,6 +38,37 @@ interface User {
   created_at: string;
 }
 
+// Mock data
+const mockUsers: User[] = [
+  {
+    id: "1",
+    email: "john.doe@example.com",
+    first_name: "John",
+    last_name: "Doe",
+    role: "admin",
+    status: "Active",
+    created_at: "2024-01-15T08:30:00Z"
+  },
+  {
+    id: "2",
+    email: "jane.smith@example.com",
+    first_name: "Jane",
+    last_name: "Smith",
+    role: "user",
+    status: "Active",
+    created_at: "2024-01-20T10:15:00Z"
+  },
+  {
+    id: "3",
+    email: "mike.johnson@example.com",
+    first_name: "Mike",
+    last_name: "Johnson",
+    role: "moderator",
+    status: "Inactive",
+    created_at: "2024-01-25T14:45:00Z"
+  }
+];
+
 const Users = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
@@ -52,42 +83,7 @@ const Users = () => {
     role: "user" as 'admin' | 'user' | 'moderator',
   });
 
-  // Mock data
-  const mockUsers: User[] = [
-    {
-      id: "1",
-      email: "john.doe@example.com",
-      first_name: "John",
-      last_name: "Doe",
-      role: "admin",
-      status: "Active",
-      created_at: "2024-01-15T08:30:00Z"
-    },
-    {
-      id: "2",
-      email: "jane.smith@example.com",
-      first_name: "Jane",
-      last_name: "Smith",
-      role: "user",
-      status: "Active",
-      created_at: "2024-01-20T10:15:00Z"
-    },
-    {
-      id: "3",
-      email: "mike.johnson@example.com",
-      first_name: "Mike",
-      last_name: "Johnson",
-      role: "moderator",
-      status: "Inactive",
-      created_at: "2024-01-25T14:45:00Z"
-    }
-  ];
-
-  useEffect(() => {
-    fetchUsers();
-  }, []);
-
-  const fetchUsers = async () => {
+  const fetchUsers = useCallback(async () => {
     setLoading(true);
     try {
       // Simulate API call
@@ -100,7 +96,11 @@ const Users = () => {
       toast.error("Failed to fetch users");
       setLoading(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
 
   const handleStatusChange = async (userId: string, newStatus: 'Active' | 'Inactive' | 'Suspended') => {
     try {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -154,5 +155,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Group gallery images by folder using their storage paths
- Allow admin uploads to target a specific folder
- Fix hook dependency warnings and replace `any` types in auth pages
- Import Tailwind plugins via ES modules

## Testing
- `npm run lint` *(fails: 40 problems (28 errors, 12 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c1178cf65483309a4e9acbff1838e7